### PR TITLE
Continue decoding on binary data

### DIFF
--- a/pysmile/decode.py
+++ b/pysmile/decode.py
@@ -341,6 +341,8 @@ def decode(string):
                     log.error('Found end-of-String marker (0xFC) in value mode')
                 elif byt == INT_MISC_BINARY_RAW:
                     log.warn('Not Yet Implemented: Raw Binary Data')
+                    smile_value_length = (byt & 0x7F) + 33
+                    state.index += smile_value_length
                 elif byt == BYTE_MARKER_END_OF_CONTENT:
                     log.debug('Token: End Marker')
                     state.mode = DecodeMode.DONE


### PR DESCRIPTION
When binary data in found on decoding, decoding is interrupted and the JSONin the output buffer is truncated.
increasing the index allow the decoding to continue, obviously the binary data isn't decoded yet.

Tested on elasticsearch state file with following code to remove extra header and footer

import json 
b = open("state-181.st", 'rb').read() 
x = b[18:-16]
d = pysmile.decode(x)
print json.dumps(d, indent=4)